### PR TITLE
Support silent android notifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pushwoosh (1.0.1)
+    pushwoosh (1.1.3)
       httparty (~> 0.13.3)
 
 GEM
@@ -12,10 +12,10 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    httparty (0.13.3)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.2)
+    json (1.8.3)
     method_source (0.8.2)
     multi_xml (0.5.5)
     pry (0.10.1)

--- a/lib/pushwoosh/push_notification.rb
+++ b/lib/pushwoosh/push_notification.rb
@@ -41,8 +41,6 @@ module Pushwoosh
     def default_notification_options
       {
         send_date: "now",
-        ios_badges: "+1",
-        ios_sound: ""
       }
     end
   end

--- a/lib/pushwoosh/version.rb
+++ b/lib/pushwoosh/version.rb
@@ -1,3 +1,3 @@
 module Pushwoosh
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/spec/lib/pushwoosh/push_notification_spec.rb
+++ b/spec/lib/pushwoosh/push_notification_spec.rb
@@ -22,7 +22,6 @@ describe Pushwoosh::PushNotification do
       {
         notification_options: {
           send_date: "now",
-          :ios_badges=>"+1",
           content: "Testing"
         },
         auth: "5555-5555",
@@ -41,14 +40,6 @@ describe Pushwoosh::PushNotification do
         expect(response_of_notify.response['Messages']).to eq ['555555534563456345']
       end
     end
-
-    context 'when message is empty' do
-      xit 'raises message is missing error' do
-        expect {
-           subject.notify_all('')
-        }.to raise_error Pushwoosh::Exceptions::Error, 'Message is missing'
-      end
-    end
   end
 
   describe '#notify_devices' do
@@ -61,7 +52,6 @@ describe Pushwoosh::PushNotification do
       {
         notification_options: {
           send_date:  "now",
-          ios_badges: "+1",
           content:    "Testing",
           devices: ["dec301908b9ba8df85e57a58e40f96f523f4c2068674f5fe2ba25cdc250a2a41",
                     'bec301908b9ba8df85e57a58e40f96f523f4c2068674f5fe2ba25cdc250a2a41']
@@ -80,14 +70,6 @@ describe Pushwoosh::PushNotification do
         expect(response_of_notify.status_code).to eq 200
         expect(response_of_notify.status_message).to eq 'OK'
         expect(response_of_notify.response['Messages']).to eq ['555555534563456345']
-      end
-    end
-
-    context 'when message is empty' do
-      it 'raises message is missing error' do
-        expect {
-          subject.notify_devices('', devices)
-        }.to raise_error Pushwoosh::Exceptions::Error, 'Message is missing'
       end
     end
   end

--- a/spec/lib/pushwoosh_spec.rb
+++ b/spec/lib/pushwoosh_spec.rb
@@ -17,13 +17,5 @@ describe Pushwoosh do
         end
       end
     end
-
-    context 'when message is empty' do
-      it  'raises a error if message is empty' do
-        VCR.use_cassette 'pushwoosh/empty_message_push' do
-          expect { described_class.notify_all("") }.to raise_error
-        end
-      end
-    end
   end
 end

--- a/spec/vcr/pushwoosh/empty_message_push.yml
+++ b/spec/vcr/pushwoosh/empty_message_push.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://cp.pushwoosh.com/json/1.3/createMessage
     body:
       encoding: UTF-8
-      string: '{"request":{"application":"5555-5555","auth":"abcdefg","notifications":[{"send_date":"now","content":"Testing"}]}}'
+      string: '{"request":{"application":"5555-5555","auth":"abcefg","notifications":[{"send_date":"now","content":""}]}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Server:
-      - nginx/1.4.2
+      - nginx/1.6.3
       Date:
-      - Sun, 11 Jan 2015 21:40:58 GMT
+      - Mon, 01 Feb 2016 19:56:10 GMT
       Content-Type:
       - application/json; charset=utf8
       Transfer-Encoding:
@@ -37,12 +37,12 @@ http_interactions:
       Access-Control-Allow-Methods:
       - GET, POST, PUT, OPTIONS
       X-Pw-Cluster-Node:
-      - api-02
+      - api-32
       X-Pw-Front-Node:
-      - front-02
+      - front-05
     body:
       encoding: UTF-8
-      string: '{"status_code":200,"status_message":"OK","response":{"Messages":["4C2C-9A52A6A4-9BA6D064"]}}'
-    http_version:
-  recorded_at: Sun, 11 Jan 2015 21:40:59 GMT
+      string: '{"status_code":210,"status_message":"Account not found","response":null}'
+    http_version: 
+  recorded_at: Mon, 01 Feb 2016 19:56:11 GMT
 recorded_with: VCR 2.8.0


### PR DESCRIPTION
- Remove specs that assume message content must exist. Silent push notifications don't have this.
- Remove hardcoded ios_badge field.
