### PR TITLE
Feature/post timeout support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pushwoosh (1.1.6)
+    pushwoosh (1.1.7)
       httparty (~> 0.13.3)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pushwoosh (1.1.5)
+    pushwoosh (1.1.6)
       httparty (~> 0.13.3)
 
 GEM
@@ -54,4 +54,4 @@ DEPENDENCIES
   webmock (~> 1.15.0)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/lib/pushwoosh/request.rb
+++ b/lib/pushwoosh/request.rb
@@ -26,13 +26,17 @@ module Pushwoosh
     end
 
     def make_post!
-      response = self.class.post(url, body: build_request.to_json).parsed_response
+      response = self.class.post(url, timeout: timeout, body: build_request.to_json).parsed_response
       Response.new(response)
     end
 
     private
 
     attr_reader :options, :base_request, :notification_options, :url
+
+    def timeout
+      ENV["PUSHWOOSH_TIMEOUT"] || 5
+    end
 
     def validations!(url, options)
       fail Pushwoosh::Exceptions::Error, 'Missing application' unless options.fetch(:application)

--- a/lib/pushwoosh/version.rb
+++ b/lib/pushwoosh/version.rb
@@ -1,3 +1,3 @@
 module Pushwoosh
-  VERSION = "1.1.6"
+  VERSION = "1.1.7"
 end

--- a/spec/lib/pushwoosh/request_spec.rb
+++ b/spec/lib/pushwoosh/request_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Pushwoosh::Request do
-
   describe '#make_post!' do
     let(:body) do
       {
@@ -48,7 +47,7 @@ describe Pushwoosh::Request do
       subject { described_class.new('/createMessage', options) }
 
       it 'sends the notification with valid params' do
-        allow(described_class).to receive(:post).with("/createMessage", body: body.to_json).and_return(response)
+        allow(described_class).to receive(:post).with("/createMessage", timeout: 5, body: body.to_json).and_return(response)
         allow(response).to receive(:parsed_response).and_return(OpenStruct.new(response_hash))
         response_of_make_post = subject.make_post!
 


### PR DESCRIPTION
Adds a default timeout of 5 seconds on POST requests. This value can be overridden via the `PUSHWOOSH_TIMEOUT` environment variable.
